### PR TITLE
General rework for Yocto Project integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,13 +4,13 @@
 #    SPDX-License-Identifier: GPL-2.0-or-later
 #==============================================================================
 
-SRC_DIR := src
-
-.PHONY: all clean
-
 all:
-	@$(MAKE) -C $(SRC_DIR)/
-	@mv $(SRC_DIR)/cst_signer .
+	@$(MAKE) -C src
+
+install:
+	@$(MAKE) -C src install
 
 clean:
-	@rm -rf cst_signer src/fdt.o
+	@$(MAKE) -C src clean
+
+.PHONY: all install clean

--- a/src/Makefile
+++ b/src/Makefile
@@ -4,23 +4,33 @@
 #    SPDX-License-Identifier: GPL-2.0-or-later
 #==============================================================================
 
-CC = gcc
+CC       ?= gcc
+CFLAGS   ?= -g -Wall -Werror
+CPPFLAGS ?=
+LDFLAGS  ?=
+INCLUDES  = -I../inc/
 
-COPTS = -g -Wall -Werror
-CFLAGS = -I../inc/.
+PREFIX   ?= /usr/local
+BINDIR   ?= $(PREFIX)/bin
+DATADIR  ?= $(PREFIX)/share
 
-DEPS = cst_signer.h cfg_parser.h mkimage_helper.h
-SRCS = cst_signer.c cfg_parser.c mkimage_helper.c fdt.o
+SRCS = cst_signer.c cfg_parser.c mkimage_helper.c fdt.c
 
-.PHONY: all clean
+all: cst-signer
 
-all: cst_signer fdt.o
+%.o : %.c
+	$(CC) -c $(INCLUDES) $(CFLAGS) $(LDFLAGS) $(CPPFLAGS) $< -o $@
 
-fdt.o: fdt.c
-	$(CC) -c -w -o $@ $< $(CFLAGS)
+cst-signer: $(SRCS:.c=.o)
+	$(CC) $(INCLUDES) $(CFLAGS) $(LDFLAGS) $(CPPFLAGS) -o $@ $(SRCS:.c=.o)
 
-cst_signer: cst_signer.c fdt.o
-	$(CC) $(COPTS) $(CFLAGS) -o $@ $(SRCS)
+install: cst-signer
+	install -D -m 0755 cst-signer $(DESTDIR)/$(BINDIR)/cst-signer
+	install -D -m 0755 -t $(DESTDIR)$(DATADIR)/doc/cst-signer \
+            ../csf_ahab.cfg.sample \
+            ../csf_hab4.cfg.sample
 
 clean:
-	rm -rf cst_signer fdt.o
+	rm -rf cst-signer *.o
+
+.PHONY: all install clean

--- a/src/cfg_parser.c
+++ b/src/cfg_parser.c
@@ -4,7 +4,7 @@
  *
  */
 
-#include "cfg_parser.h"
+#include <cfg_parser.h>
 
 #define DELIMITER       "="
 

--- a/src/cst_signer.c
+++ b/src/cst_signer.c
@@ -4,11 +4,13 @@
  *
  */
 
-#include "cst_signer.h"
-#include "cfg_parser.h"
-#include "mkimage_helper.h"
-#include "fdt.h"
 #include <limits.h>
+
+#include <cst_signer.h>
+#include <cfg_parser.h>
+#include <mkimage_helper.h>
+#include <fdt.h>
+
 #define RSIZE   256
 
 uint32_t g_image_offset = 0;

--- a/src/fdt.c
+++ b/src/fdt.c
@@ -13,7 +13,8 @@
 #include <limits.h>
 #include <stdio.h>
 #include <string.h>
-#include "fdt.h"
+
+#include <fdt.h>
 
 
 static struct fdt_errtabent fdt_errtable[] = {


### PR DESCRIPTION
The two commit messages provide information about the changes made in the code:

1. Fix include of headers so it indicates it uses the includedir:
   - This commit fixes the incorrect inclusion of headers in the code. It updates the include statements to indicate that they use the `includedir`.

2. Improve Makefile so it is overridable and provides standardized targets:
   - This commit improves the Makefile by reworking the targets. It provides a standardized set of targets and allows the overriding of variables. This is done to support cross-compiling properly. Additionally, it fixes an issue related to Issue #1.