### PR TITLE
Experimental support for pkcs#11

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,27 @@ Build this tool using `make` command.
 
 ---
 
+### Sign images using hardware backed cryptographic keys "--pkcs11"
+This introduces a few changes to nxp-cst--signer for secure hardware singing.
+This code is experimental, and has been tested with AHAB mimx9352.
+
+Steps required 
+- Works currently on linux
+- build nxp-cst-signer
+- build cst-3.4.1 (make sure the copmiled binary is in ${CST_PATH}/code/build director)
+- make sure that you have PKCS11_MODULE_PATH to the pkcs#11 library when executing cst-signer
+- make sure to set the PKCS#11 as key in the csf.
+
+Note: 
+- The benfit of using this is that it protects private key from exposure.
+- Make sure that you use a have a recoverable backup of your private key.
+- The solution protects the private key from exposure of normal usage.
+
+PKCS#11 is expeimental support is added for linux, append --pkcs11
+In order for this to work, PKCS11_MODULE_PATH must be set before invoking 
+
+----
+
 ### Run
 
 To run this tool, along with CST, you would also need to have the CSF config 

--- a/inc/cst_signer.h
+++ b/inc/cst_signer.h
@@ -20,7 +20,7 @@
         Command line arguments
 ************************/
 /* Valid short command line option letters. */
-const char* const short_opt = "hfdi:o:c:";
+const char* const short_opt = "hfdi:o:c:p:";
 
 /* Valid long command line options. */
 const struct option long_opt[] =
@@ -30,6 +30,7 @@ const struct option long_opt[] =
     {"offset", required_argument,  0, 'o'},
     {"debug", no_argument,  0, 'd'},
     {"fdt-debug", no_argument,  0, 'f'},
+    {"pkcs11", no_argument,  0, 'p'},
     {"help", no_argument, 0, 'h'},
     {NULL, 0, NULL, 0}
 };
@@ -42,6 +43,7 @@ const char* desc_opt[] =
     "(Optional) Offset to the start of image",
     "(Optional) Enable debug information",
     "(Optional) FDT debug information",
+    "(Optional) Enable pkcs#11 signing. Currently only Linux support, and for cst-3.4.1 you must compile the source",
     "This text",
     NULL
 };
@@ -186,6 +188,7 @@ static bool g_debug = 0;
 static char *g_csf_cfgfilename = NULL;
 extern uint32_t g_image_offset;
 static char *g_cst_path = NULL;
+static bool g_pkcs11 = 0;	// static to enable pkcs#11 signing
 
 unsigned char g_ivt_v1_mask[] = {0xFF,0xFF,0xFF,0xF0};
 unsigned char g_ivt_v1[] = {0xD1,0x00,0x20,0x41};


### PR DESCRIPTION
Use nxp-cst-signer with cst, and sign images using pkcs11 tokens
* Follow the README
* Have been tested with cst-3.4.1 (re-compiled version)
* Yubikey 5
* Ubuntu 22.04 LTS
